### PR TITLE
docker-stack.yml の mariadb でマルチバイト文字を扱えない問題の修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   mariadb:
+    command: "mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
     environment:
       MYSQL_ROOT_PASSWORD: "password"
     expose:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   mariadb:
+    command: "mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
     environment:
       MYSQL_DATABASE: "cojtswbp_database"
       MYSQL_PASSWORD: "cojtswbp_password"


### PR DESCRIPTION
次コマンドで起動すると，何故か日本語がうまく扱えなかったので，修正．

```
docker-compose -f docker-stack.yml up
```

`docker-stack.yml`に文字コードの指定を追加．
また，開発環境にも文字コードを追加し統一．

以下エラー現象
- 日本語を含むメッセージを投稿すると，500で落ちる現象が発生．
  - `docker-compose.yml`では正常に動作していることを確認．
  `docker-stack.yml`のときのみ当該現象が発生．
- データベースでマルチバイト文字エラーになってた模様．
- mariadbに関しては，差分がボリュームを使っているかどうかだけなので，
おそらくそれが原因でマルチバイト文字が扱えるかの問題が発生．
- ubuntu 18.04 で現象を確認．
  - `Linux guz 4.15.0-22-generic #24-Ubuntu SMP Wed May 16 12:15:17 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux`

```
irb(main):001:0> Comment.create(body: 'hoge')
   (0.6ms)  SET NAMES utf8,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
   (0.5ms)  BEGIN
  Comment Create (1.0ms)  INSERT INTO `comments` (`body`, `user_name`, `created_at`, `updated_at`) VALUES ('hoge', 'Anonymous', '2018-06-15 12:30:19', '2018-06-15 12:30:19')
D, [2018-06-15T12:30:19.342881 #112] DEBUG -- :   SOLR Request (19.6ms)  [ path=update parameters={} ]
   (4.7ms)  COMMIT
[IdentityCache] expiring=Comment expiring_id=2 expiring_last_updated_at=
[IdentityCache] delete recorded for IDC:7:blob:Comment:10099942018402847000:2
=> #<Comment id: 2, body: "hoge", user_display_name: nil, user_name: "Anonymous", created_at: "2018-06-15 12:30:19", updated_at: "2018-06-15 12:30:19", comment_id: nil>
irb(main):002:0> Comment.create(body: 'ほげ')
Traceback (most recent call last):
SyntaxError ((irb):2: invalid multibyte char (US-ASCII))
(irb):2: invalid multibyte char (US-ASCII)
(irb):2: invalid multibyte char (US-ASCII)
(irb):2: invalid multibyte char (US-ASCII)
(irb):2: invalid multibyte char (US-ASCII)
(irb):2: invalid multibyte char (US-ASCII)
irb(main):003:0>
```
