### PR TITLE
シングルクォートをtextに入れると文字化けする問題の修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
 
   def comment_body_format(body)
     raw(html_escape(body)
-            .gsub(/#([^#\p{Space}]+)/, tag.a('#\1', href: root_path(body: '\1').gsub(/%5C/, '%23\\')))
+            .gsub(/[^&]#([^#\p{Space}]+)/, tag.a('#\1', href: root_path(body: '\1').gsub(/%5C/, '%23\\')))
             .gsub(/\r\n/, tag.br))
   end
 end


### PR DESCRIPTION
fix #80

エスケープすると &#39; に変換され，それがハッシュタグ認定されるのに起因するバグでした．