### PR TITLE
user_name に一部記号を入れると 500 となる問題の修正

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -27,7 +27,8 @@ class Comment < ApplicationRecord
 
   def crypt_user_name
     self.user_name = if user_name.present?
-                       user_name.crypt(user_name + 'salt').slice(2, 10)
+                       salt = user_name.split('').select {|c| /[A-Za-z0-9.\/]/ =~ c}.join('') + 'salt'
+                       user_name.crypt(salt).slice(2, 10)
                      else
                        'Anonymous'
                      end


### PR DESCRIPTION
fix #79

user_name に一部記号を入れると 500 となる問題の修正
crypt 系のエラーでした．